### PR TITLE
Add ability to set custom HTML

### DIFF
--- a/src/WebOTA.cpp
+++ b/src/WebOTA.cpp
@@ -152,12 +152,9 @@ int WebOTA::add_http_routes(WebServer *server, const char *path) {
 	// Upload firmware page
 	server->on(path, HTTP_GET, [server,this]() {
 		String html = "";
-		if (this->custom_html != NULL)
-		{
+		if (this->custom_html != NULL) {
 			html += this->custom_html;
-		}
-		else
-		{
+		} else {
 			html += ota_version_html;
 		}
 
@@ -223,8 +220,7 @@ void WebOTA::delay(unsigned int ms) {
 	}
 }
 
-void WebOTA::set_custom_html(char const * const html)
-{
+void WebOTA::set_custom_html(char const * const html) {
 	this->custom_html = html;
 }
 ///////////////////////////////////////////////////////////////////////////

--- a/src/WebOTA.cpp
+++ b/src/WebOTA.cpp
@@ -78,8 +78,9 @@ long WebOTA::max_sketch_size() {
 }
 
 // R Macro string literal https://en.cppreference.com/w/cpp/language/string_literal
-const char ota_html[] PROGMEM = "<h1>WebOTA Version: " WEBOTA_VERSION "</h1>"
-R"!^!(
+const char ota_version_html[] PROGMEM = "<h1>WebOTA Version: " WEBOTA_VERSION "</h1>";
+
+const char ota_upload_form[] PROGMEM = R"!^!(
 
 <form method="POST" action="#" enctype="multipart/form-data" id="upload_form">
     <input type="file" name="update" id="file">
@@ -150,7 +151,18 @@ int WebOTA::add_http_routes(WebServer *server, const char *path) {
 
 	// Upload firmware page
 	server->on(path, HTTP_GET, [server,this]() {
-		server->send_P(200, "text/html", ota_html);
+		String html = "";
+		if (this->custom_html != NULL)
+		{
+			html += this->custom_html;
+		}
+		else
+		{
+			html += ota_version_html;
+		}
+
+		html += ota_upload_form;
+		server->send_P(200, "text/html", html.c_str());
 	});
 
 	// Handling uploading firmware file
@@ -211,6 +223,10 @@ void WebOTA::delay(unsigned int ms) {
 	}
 }
 
+void WebOTA::set_custom_html(char const * const html)
+{
+	this->custom_html = html;
+}
 ///////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////
 

--- a/src/WebOTA.h
+++ b/src/WebOTA.h
@@ -26,9 +26,12 @@ class WebOTA {
 #endif
 
 		int handle();
+
+		void set_custom_html(char const * const html);
+
 	private:
 		bool init_has_run;
-
+		char const * custom_html = NULL;
 		String get_ota_html();
 		long max_sketch_size();
 };


### PR DESCRIPTION
With reference to issue #12 , a simple implementation of user-settable custom HTML.

Defaults to using the default WebOTA header, but can be overridden by use of the set_custom_html method.

I kept the changes as simple as possible.