### PR TITLE
Add FlashHelper FPSTR() to HTML string to fix a crash.

### DIFF
--- a/src/WebOTA.cpp
+++ b/src/WebOTA.cpp
@@ -155,10 +155,10 @@ int WebOTA::add_http_routes(WebServer *server, const char *path) {
 		if (this->custom_html != NULL) {
 			html += this->custom_html;
 		} else {
-			html += ota_version_html;
+			html += FPSTR(ota_version_html);
 		}
 
-		html += ota_upload_form;
+		html += FPSTR(ota_upload_form);
 		server->send_P(200, "text/html", html.c_str());
 	});
 


### PR DESCRIPTION
Fixes issue https://github.com/scottchiefbaker/ESP-WebOTA/issues/14.

See details here https://arduino.stackexchange.com/questions/70391/esp8266-stops-working-when-i-use-2x-static-const-charprogmem.