### PR TITLE
initialize variable "init_has_run"

### DIFF
--- a/src/WebOTA.h
+++ b/src/WebOTA.h
@@ -31,7 +31,7 @@ class WebOTA {
 		void useAuth(const char* user, const char* password);
 
 	private:
-		bool init_has_run;
+		bool init_has_run = false;
 		char const * custom_html = NULL;
 		String get_ota_html();
 		String human_time(uint32_t sec);


### PR DESCRIPTION
so that cppcheck (e.g. in platformio) does not complain about it anymore like:

CWE-398:Member variable 'WebOTA::init_has_run' is not initialized.

I know, the default of a bool most likely is false, but this just makes sure it is.

I also know that there is no recent activity, but hope dies last :>